### PR TITLE
TS client - export types

### DIFF
--- a/generators/tstypes/testdata/todo_types.ts
+++ b/generators/tstypes/testdata/todo_types.ts
@@ -1,5 +1,5 @@
 // Item is a to-do item.
-interface Item {
+export interface Item {
   // created_at is the time the to-do item was created.
   created_at?: Date
 

--- a/generators/tstypes/tstypes.go
+++ b/generators/tstypes/tstypes.go
@@ -16,7 +16,7 @@ func Generate(w io.Writer, s *schema.Schema) error {
 	// types
 	for _, t := range s.TypesSlice() {
 		out(w, "// %s %s\n", format.GoName(t.Name), t.Description)
-		out(w, "interface %s {\n", format.GoName(t.Name))
+		out(w, "export interface %s {\n", format.GoName(t.Name))
 		writeFields(w, s, t.Properties)
 		out(w, "}\n\n")
 	}


### PR DESCRIPTION
Exported types so they can be used in method definitions etc. when passed around.
