### PR TITLE
TS: use camel case in object field names

### DIFF
--- a/generators/tstypes/testdata/todo_types.ts
+++ b/generators/tstypes/testdata/todo_types.ts
@@ -1,7 +1,7 @@
 // Item is a to-do item.
 export interface Item {
-  // created_at is the time the to-do item was created.
-  created_at?: Date
+  // createdAt is the time the to-do item was created.
+  createdAt?: Date
 
   // id is the id of the item. This field is read-only.
   id?: number

--- a/generators/tstypes/tstypes.go
+++ b/generators/tstypes/tstypes.go
@@ -64,11 +64,12 @@ func writeFields(w io.Writer, s *schema.Schema, fields []schema.Field) {
 
 // writeField to writer.
 func writeField(w io.Writer, s *schema.Schema, f schema.Field) {
-	fmt.Fprintf(w, "  // %s is %s%s\n", f.Name, f.Description, schemautil.FormatExtra(f))
+	name := format.JsName(f.Name)
+	fmt.Fprintf(w, "  // %s is %s%s\n", name, f.Description, schemautil.FormatExtra(f))
 	if f.Required {
-		fmt.Fprintf(w, "  %s: %s\n", f.Name, jsType(s, f))
+		fmt.Fprintf(w, "  %s: %s\n", name, jsType(s, f))
 	} else {
-		fmt.Fprintf(w, "  %s?: %s\n", f.Name, jsType(s, f))
+		fmt.Fprintf(w, "  %s?: %s\n", name, jsType(s, f))
 	}
 }
 


### PR DESCRIPTION
We should use camel-case in interfaces generated from the schema as that's the ts/js convention. Implemented a decoder and encoder to convert fields in API objects to/from snake-case/camel-case.

Resolves #40 